### PR TITLE
Feat/clustered options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,3 +37,6 @@ minio_enable_circuitbreaker: true
 
 # Run frequency of the circuit breaker in systemd timer format(OnCalendar)
 minio_circuitbreaker_frequency: minutely
+
+minio_storage_class_standard: ""
+minio_storage_class_rrs: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,3 +31,9 @@ minio_secret_key: ""
 # Switches to enable/disable the minio server and/or minio client installation.
 minio_install_server: true
 minio_install_client: true
+
+# Enable the minio clustered circuit breaker
+minio_enable_circuitbreaker: true
+
+# Run frequency of the circuit breaker in systemd timer format(OnCalendar)
+minio_circuitbreaker_frequency: minutely

--- a/files/circuit-break.service
+++ b/files/circuit-break.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=circuit-breaker script for Minio
+Wants=network-online.target
+After=network-online.target
+AssertFileIsExecutable=/usr/local/bin/circuit-breaker
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/circuit-breaker
+
+StandardOutput=journal
+StandardError=inherit
+
+SuccessExitStatus=0
+
+[Install]
+WantedBy=multi-user.target

--- a/tasks/circuitbreaker.yml
+++ b/tasks/circuitbreaker.yml
@@ -1,0 +1,46 @@
+---
+- name: install circuit breaker requirements
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - fping
+    - iptables
+  register: _install_packages
+  until: _install_packages is succeeded
+  retries: 5
+  delay: 2
+
+- name: Create circuit breaker systemd service
+  copy:
+    src: ./files/circuit-break.service
+    dest: /etc/systemd/system/circuit-break.service
+    mode: 0644
+    owner: root
+    group: root
+
+- name: create the circuit breaker systemd timer
+  template:
+    src: circuit-breaker.timer.j2
+    dest: "/etc/systemd/system/circuit-break.timer"
+  when: ansible_service_mgr == "systemd"
+
+- name: create the circuit breaker script
+  template:
+    src: circuit-breaker.j2
+    dest: "/usr/local/bin/circuit-breaker"
+    mode: 0750
+
+- name: enable and start the minio service
+  service:
+    name: circuit-break
+    daemon_reload: true
+    state: started
+    enabled: true
+
+- name: enable and start the minio service
+  service:
+    name: circuit-break.timer
+    daemon_reload: true
+    state: started
+    enabled: true

--- a/tasks/circuitbreaker.yml
+++ b/tasks/circuitbreaker.yml
@@ -21,7 +21,7 @@
 
 - name: create the circuit breaker systemd timer
   template:
-    src: circuit-breaker.timer.j2
+    src: circuit-break.timer.j2
     dest: "/etc/systemd/system/circuit-break.timer"
   when: ansible_service_mgr == "systemd"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,3 +36,6 @@
 
 - include: client.yml
   when: minio_install_client
+
+- include: circuitbreaker.yml
+  when: minio_enable_circuitbreaker

--- a/templates/circuit-break.timer.j2
+++ b/templates/circuit-break.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the Minio circuit breaker service 
+
+[Timer]
+AccuracySec=1
+OnCalendar={{ minio_circuitbreaker_frequency }}
+RemainAfterElapse=no
+Unit=circuit-break.service
+
+[Install]
+WantedBy=timers.target

--- a/templates/circuit-breaker.j2
+++ b/templates/circuit-breaker.j2
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+##
+## Requirements:
+## -------------
+##
+## - fping
+## - iptables
+
+{% set minio_nodes = minio_server_cluster_nodes | join('" "') | replace("http://", "") | regex_replace ('/*', "") %}
+
+NODES=("{{ minio_nodes }}")
+
+for NODE in ${NODES[@]}
+do
+  if [  "$NODE" != "$HOSTNAME" ]; then
+    RULE="-d $NODE -p tcp --dport 9000 -j REJECT --reject-with tcp-reset"
+    if ! fping -c1 -t500 "$NODE" >/dev/null 2>&1; then
+      if ! iptables -C OUTPUT $RULE >/dev/null 2>&1; then
+        logger -t minio-circuit-breaker "disabling $NODE"
+        iptables -A OUTPUT $RULE 
+      fi
+    else
+      if iptables -C OUTPUT $RULE >/dev/null 2>&1; then
+        logger -t minio-circuit-breaker "re-enabling $NODE"
+        iptables -D OUTPUT $RULE
+      fi
+    fi
+  fi
+done

--- a/templates/circuit-breaker.j2
+++ b/templates/circuit-breaker.j2
@@ -7,7 +7,7 @@
 ## - fping
 ## - iptables
 
-{% set minio_nodes = minio_server_cluster_nodes | join('" "') | replace("http://", "") | regex_replace ('/*', "") %}
+{% set minio_nodes = minio_server_cluster_nodes | join('" "') | replace("http://", "") | regex_replace ('\/[a-zA-Z0-9]+', "") | regex_replace (':[0-9]+', "") %}
 
 NODES=("{{ minio_nodes }}")
 

--- a/templates/circuit-breaker.j2
+++ b/templates/circuit-breaker.j2
@@ -7,6 +7,7 @@
 ## - fping
 ## - iptables
 
+# This line sets the variable minio_nodes with only the hostnames separeted by a space, without protocol, port and path.
 {% set minio_nodes = minio_server_cluster_nodes | join('" "') | replace("http://", "") | regex_replace ('\/[a-zA-Z0-9]+', "") | regex_replace (':[0-9]+', "") %}
 
 NODES=("{{ minio_nodes }}")

--- a/templates/minio.env.j2
+++ b/templates/minio.env.j2
@@ -7,7 +7,7 @@ MINIO_VOLUMES="{{ minio_server_cluster_nodes | join(' ') }}"
 MINIO_VOLUMES="{{ minio_server_datadirs | join(' ') }}"
 {% endif %}
 # Minio cli options.
-MINIO_OPTS="--address {{ minio_server_addr }} {{ minio_server_opts }}"
+MINIO_OPTS="{{ minio_server_opts }}"
 
 {% if minio_access_key %}
 # Access Key of the server.
@@ -16,4 +16,12 @@ MINIO_ACCESS_KEY="{{ minio_access_key }}"
 {% if minio_secret_key %}
 # Secret key of the server.
 MINIO_SECRET_KEY="{{ minio_secret_key }}"
+{% endif %}
+
+{% if minio_storage_class_standard %}
+MINIO_STORAGE_CLASS_STANDARD="{{ minio_storage_class_standard }}"
+{% endif %}
+
+{% if minio_storage_class_rrs %}
+MINIO_STORAGE_CLASS_RRS="{{ minio_storage_class_rrs }}"
 {% endif %}


### PR DESCRIPTION
Add a circuit break script. The default timeout is too high and cannot be changed. If a node goes down the cluster takes too long to became available again

Add support for setting MINIO_STORAGE_CLASS_STANDARD and MINIO_STORAGE_CLASS_RRS as described here: https://github.com/minio/minio/tree/master/docs/erasure/storage-class